### PR TITLE
Added systemd information:

### DIFF
--- a/creating/creating_index.adoc
+++ b/creating/creating_index.adoc
@@ -87,6 +87,72 @@ way.  The following table describes the defined action-oriented labels.
 
 === Verifying your Dockerfile (linter)
 
+=== Starting your application
+
+Generally the RUN instruction in the Dockerfile is used by docker to start your application
+when the image or container is started.  In the planning section, we provided some reasoning
+for choosing how to  *_xref:planning_starting_application[start your application]_*.  The following
+subsections will show how to implement each choice in your Dockerfile.
+
+==== Calling the binary directly
+Being the simplest of the choices, you simply need to call the binary using the CMD instruction
+in your Dockerfile.
+
+```
+CMD ["/usr/bin/some_binary"]
+```
+
+[[creating_using_a_script]]
+==== Using a script
+Using a script to start an application is very similar to calling the binary directly. Again, you
+use the CMD instruction but instead of pointing at the binary you point at your script that was
+injected into the image.  The _registry.access.redhat.com/rhel7/rsyslog_ image uses a script
+to start the rsyslogd application. Lets look at the two relevant instructions in its Dockerfile
+that make this happen.
+
+The following instruction injects our script (rsyslog.sh) into the image in the _bin_ dir.
+```
+ADD rsyslog.sh /bin/rsyslog.sh
+```
+
+The contents of the script are as follows:
+
+```
+#!/bin/sh
+# Wrapper to start rsyslog.d with appropriate sysconfig options
+
+echo $$ > /var/run/syslogd.pid
+
+source /etc/sysconfig/rsyslog
+exec /usr/sbin/rsyslogd -n $SYSLOGD_OPTIONS
+```
+
+Notice how the script does in fact handle environment variables by sourcing the _/etc/sysconfig/rsyslog_
+file. And the CMD instruction simply calls the script.
+
+```
+CMD [ "/bin/rsyslog.sh" ]
+```
+
+==== Using systemd
+
+Extending our example from link:creating_using_a_script[starting an application with a script], the rsyslog
+image was started with a script.  We could easily use systemd to start the application.  To use systemd
+to start a service that has an unit file, we need to tell systemd to enable the service and then let the
+init process handle the rest.  So instead of the ADD instruction used earlier, we would use a RUN
+instruction to enable the service.
+
+```
+RUN systemctl enable rsyslog
+```
+
+And then we need to change the CMD instruction to call _/usr/sbin/init_ to let systemd take over.
+
+```
+RUN /usr/sbin/init
+```
+
+
 // Help section
 === Creating a Help file
 include::help.adoc[]

--- a/planning/planning_index.adoc
+++ b/planning/planning_index.adoc
@@ -22,11 +22,38 @@ Careful planning is important when working with container technology.
 
 ==== help files
 
-=== Best way to start your application
+[[planning_starting_application]]
+=== Starting your applications within a container
+At some point in the design of your Dockerfile and image, you will need to determine how to start your
+application.  There are three prevalent methods for starting applications:
 
-==== Should you use systemd within your container
+- Call the application binary directly
+- Call a script that results in your binary starting
+- Use systemd to start the application
 
-==== Should you construct an init script?
+For the most part, there is no single right answer on which method should be used; however, there are
+some softer decision points that might help you decide which would be easiest for you as the
+Dockerfile owner.
+
+==== Calling the binary directly
+If your application is not service oriented, calling the binary directly might be the simplest and most
+straight-forward method to start a container.  There is no memory overhead and no additional packages
+are needed (like systemd and its dependancies).  However, it is more difficult to deal with
+setting environment variables.
+
+==== Using a script
+Using a special script to start your application in a container can be a handy way to deal with slightly
+more complex applications.  One upside is that it is generally trivial to set environment variables.  This
+method is also good when you need to call more than a single binary to start the application correctly.
+One downside is that you now have to maintain the script and ensure it is always present in the image.
+
+==== Use systemd
+Using systemd to start your application is a great if your application is service oriented (like httpd).
+It can benefit from leveraging well tested unit files generally delivered with the applications
+themselves and therefor can make complex applications that require environment variables easy to work
+with.  One disadvantage is that systemd will increase the size of your image and there is a small
+amount of memory used for systemd itself.
+
 
 === Plan your network
 


### PR DESCRIPTION
Adding how one chooses to start an application image whether
by calling binary directly, using a script, or deferring to
systemd.  This went into the planning information.

In the creating section, added sections on how to start
the application with each of these methods.
