### PR TITLE
creating/creating_index.adoc: Add Dockerfile location

### DIFF
--- a/creating/creating_index.adoc
+++ b/creating/creating_index.adoc
@@ -492,7 +492,14 @@ include::help.adoc[]
 
 === Verifying Dockerfile (linter)
 
+=== Dockerfiles
 
+The Dockerfiles for many of the public images are hosted in git repositories where users can view
+them.  This also allows users to customize them as well.
+
+It is also good practice to include the Dockerfile in the image itself.  Some distributions have begun to
+include an image's Dockerfile in the directory _/root/buildinfo_.  Consider following the same
+approach to make sure your Dockerfiles can be easily found.
 
 
 OLD - OLD - OLD - OLD - OLD - OLD - OLD - OLD - OLD - OLD - OLD - OLD - OLD - OLD - OLD - OLD - OLD - OLD -


### PR DESCRIPTION
Add the best practice to always include your dockerfile
in a known location of the image's filesystem.  This allows
people to find it readily.
