### PR TITLE
Using the host's systemd to manage images/containers

### DIFF
--- a/creating/creating_index.adoc
+++ b/creating/creating_index.adoc
@@ -464,7 +464,8 @@ file. And the CMD instruction simply calls the script.
 CMD [ "/bin/rsyslog.sh" ]
 ```
 
-==== Using systemd
+[[creating_using_systemd]]
+==== Using systemd "inside the container"
 
 Extending our example from link:creating_using_a_script[starting an application with a script], the rsyslog
 image was started with a script.  We could easily use systemd to start the application.  To use systemd
@@ -481,6 +482,82 @@ And then we need to change the CMD instruction to call _/usr/sbin/init_ to let s
 ```
 RUN /usr/sbin/init
 ```
+
+==== Using systemd to control containers
+
+The control mechanism for most docker functions is done via the docker commands or something like
+the atomic application which simplifies the management of containers and images for users.  But in
+a non-development environment, you may wish to treat your containers more like traditional services
+or applications.  For example, you may wish to have your containers start in a specific order on
+boot-up.  Or perhaps you wish to be able to restart (or recycle) a container because you have changed
+its configuration file.
+
+There are several approaches to these sorts of function.  You can make sure a specific container
+always starts on boot-up using the --restart switch with the docker command line when you initially
+run the image.  There are also orchestration platforms like Kubernetes that will allow you to determine the
+start up order of containers even when they are distributed.  But in the case where all the containers
+reside on a single node, systemd might just be exactly the solution.  Like with traditional services,
+systemd is capable of making sure services both start and in the order they are specified.  Moreover,
+any issues with startup or the container are logged like any other system service.
+
+When using systemd to manage your containers, you are really using systemd to call docker commands (and
+subsequently the docker daemon) to perform the actions.  Therefore, once you commit to using systemd
+to control a container, you will need to make sure that all stop, stop, and restart actions are
+conducted with systemd.  Failure to do so essentially decouples the docker daemon and systemd causing
+systemd to be out of sync.
+
+In review, systemd is a good solution for:
+
+* host system services such as agents and long-running services
+* logging via journald
+* service dependant management
+* traditional service management vis _systemctl_
+* multi-container applications with dependencies on the same node
+
+
+The configuration file below is a sample service file that can be used and edited to control your image or
+container.  In the [Unit] section, you can declare other services needed by your image including the cases where
+those services are also images.
+
+.Sample template for a systemd service file
+```
+[Unit]
+After=docker.service
+Requires=docker.service
+PartOf=docker.service
+After=[cite another service]
+Wants=[cite another service]
+
+[Service]
+EnvironmentFile=[path to configuration file]
+ExecStartPre=-[command to execute prior to starting]
+ExecStart=[command to execute for start]
+ExecStartPost=/usr/bin/sleep 10
+ExecStop=[command to execute for stop]
+Restart=always
+
+[Install]
+WantedBy=docker.service
+```
+
+In the [Service] section, you can also declare the actual commands that should be run prior to start, in the
+case of start, and in the case of stop.  These commands can either be straight base commands or docker run (or stop)
+commands as well.  Finally, if you are using a well made image that contains labels like STOP or RUN, you
+could also use the atomic command.  For example, a start command could simply be:
+
+```
+atomic run <image_name>
+```
+
+This works because the actual docker command to run that image is part of the image's metadata and atomic is
+capable of extracting it.
+
+The [Service] section also has an option for EnvironmentFile.  In a traditional, non-containerized systemd service,
+this configuration file resides in _/etc/sysconfig/<service_name>_.  In the case of a containerized application,
+these configuration files are not always configurable and therefore do not reside on the host's filesystem.  And
+in the case of where they are configurable, the EnvironmentFile is usually more important to how the service
+application is started.  If you are link:planning_use_system[dstarting the application] within an image
+with systemd, then systemd will use _/etc/sysconfig/<service_name>_ within the image itself.
 
 
 // Help section

--- a/planning/planning_index.adoc
+++ b/planning/planning_index.adoc
@@ -97,6 +97,7 @@ more complex applications.  One upside is that it is generally trivial to set en
 method is also good when you need to call more than a single binary to start the application correctly.
 One downside is that you now have to maintain the script and ensure it is always present in the image.
 
+[[planning_use_systemd]]
 ==== Use systemd
 Using systemd to start your application is a great if your application is service-oriented (like httpd).
 It can benefit from leveraging well tested unit files generally delivered with the applications
@@ -106,6 +107,8 @@ amount of memory used for systemd itself.
 
 NOTE: As of docker-1.10, the docker run parameter of _--privileged_ is no longer needed to use systemd
 within a container.
+
+You can implement using link:creating_using_systemd[systemd fairly simply in your Dockerfile].
 
 === Techniques for deploying or starting images from a host
 ==== host systemd considerations


### PR DESCRIPTION
Created a section that discusses the role of systemd on the host
to manage (start/stop/restart) images as if they were a system
service.
